### PR TITLE
use port 80 instead of 53 by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ pub struct Opt {
     #[structopt(short, long, default_value = "2")]
     pub interval: f32,
     /// Host IP to connect to when checking ping
-    #[structopt(long, default_value = "1.1.1.1:53")]
+    #[structopt(long, default_value = "1.1.1.1:80")]
     pub host: SocketAddr,
     /// Disables desktop notifications on profile start/stop
     #[structopt(short)]


### PR DESCRIPTION
Port 53 is blocked by some VPNs [1] to prevent DNS leaks. Since we are
connecting to 1.1.1.1, which runs an HTTP endpoint on :80, this will
work with VPNs and unprotected connections alike.

[1]: https://mullvad.net/en/help/terms-service/